### PR TITLE
Fix SubscriberBlackboxSpec timeout

### DIFF
--- a/src/main/scala/fs2/interop/reactive/fromPublisher.scala
+++ b/src/main/scala/fs2/interop/reactive/fromPublisher.scala
@@ -196,7 +196,7 @@ object SubscriberQueue extends LazyLogging {
               r.get
             case Idle(sub) =>
               logger.info(s"$this received request when idle [$sub]")
-              AA.delay(sub.request(1)).flatMap( _ => r.get)
+              AA.pure(sub.request(1)).flatMap( _ => r.get)
             case Errored(err) =>
               logger.error(s"$this dequeueing error [${err}]")
               AA.pure(Attempt.failure(err))

--- a/src/main/scala/fs2/interop/reactive/fromPublisher.scala
+++ b/src/main/scala/fs2/interop/reactive/fromPublisher.scala
@@ -109,13 +109,13 @@ object SubscriberQueue extends LazyLogging {
         }.flatMap { _.previous match {
           case _ : FirstRequest => 
               logger.info(s"$this received subscription after request")
-            AA.delay(s.request(1))
+            AA.pure(s.request(1))
           case Uninitialized =>
               logger.info(s"$this received subscription when uninitialized")
             AA.pure(())
           case o => 
               logger.info(s"$this received subscription in invalid state [$o]")
-            AA.delay(s.cancel()) >> AA.fail(new Error(s"received subscription in invalid state [$o]"))
+            AA.pure(s.cancel()) >> AA.fail(new Error(s"received subscription in invalid state [$o]"))
         }}
 
         def onNext(a: A): Task[Unit] = qref.modify {
@@ -169,12 +169,12 @@ object SubscriberQueue extends LazyLogging {
         }.flatMap { _.previous match {
           case PendingElement(sub, r) =>
             logger.info(s"$this finalized when pending elements")
-            AA.delay {
+            AA.pure {
             sub.cancel()
           } >> r.setPure(Attempt.success(None))
           case Idle(sub) =>
             logger.info(s"$this finalized when idle")
-            AA.delay {
+            AA.pure {
             sub.cancel()
           }
           case o =>

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,2 +1,4 @@
+org.slf4j.simpleLogger.log.fs2.interop.reactive.UnicastPublisher$=error
+org.slf4j.simpleLogger.log.fs2.interop.reactive.UnicastPublisherSpec=error
 org.slf4j.simpleLogger.defaultLogLevel=trace
 org.slf4j.simpleLogger.showDateTime=true


### PR DESCRIPTION
The `SubscriberBlackboxSpec` fails as a result of a timeout.  Operations in the subscriber have been changed to `pure` instead of `delay`.   This will reduce the time taken for a response.