### PR TITLE
Make StreamUnicastPublisher work with multiple threads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 
 lazy val buildSettings = Seq(
   organization := "com.github.zainab-ali",
-  crossScalaVersions := List("2.12.2", "2.11.11"),
+  crossScalaVersions := List("2.12.3", "2.11.11"),
   scalaVersion := crossScalaVersions.value.head,
   name := "fs2-reactive-streams"
 )
@@ -37,17 +37,17 @@ lazy val commonSettings = Seq(
   resolvers := commonResolvers,
   scalacOptions ++= commonScalacOptions,
   libraryDependencies ++= Seq(
-    "co.fs2" %% "fs2-core" % "0.10.0-M2",
+    "co.fs2" %% "fs2-core" % "0.10.0-M5",
     "org.reactivestreams" % "reactive-streams" % "1.0.0",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.3" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",
     "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test"
   )
 ) ++ coverageSettings ++ buildSettings
 
 lazy val docSettings = tutSettings ++ Seq(
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.5.0"
+    "com.typesafe.akka" %% "akka-stream" % "2.5.3"
   ),
   tutTargetDirectory := (baseDirectory in ThisBuild).value
 )

--- a/build.sbt
+++ b/build.sbt
@@ -38,10 +38,10 @@ lazy val commonSettings = Seq(
   scalacOptions ++= commonScalacOptions,
   libraryDependencies ++= Seq(
     "co.fs2" %% "fs2-core" % "0.10.0-M5",
-    "org.reactivestreams" % "reactive-streams" % "1.0.0",
+    "org.reactivestreams" % "reactive-streams" % "1.0.1",
     "org.scalatest" %% "scalatest" % "3.0.3" % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",
-    "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test"
+    "org.reactivestreams" % "reactive-streams-tck" % "1.0.1" % "test"
   )
 ) ++ coverageSettings ++ buildSettings
 

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -11,23 +11,25 @@ import scala.concurrent.ExecutionContext
 /** Implementation of an org.reactivestreams.Publisher.
   *
   * This is used to publish elements from an fs2.Stream to a downstream reactivestreams system.
-  * 
+  *
   * @see https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code
   *
   */
-final class StreamUnicastPublisher[F[_], A](val s: Stream[F, A])(implicit AA: Effect[F], ec: ExecutionContext) extends Publisher[A] {
+final class StreamUnicastPublisher[F[_]: Effect, A](val s: Stream[F, A])
+                                                   (implicit ec: ExecutionContext) extends Publisher[A] {
 
   def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
     nonNull(subscriber)
-    async.unsafeRunAsync(StreamSubscription(subscriber, s).map { sub =>
-      subscriber.onSubscribe(sub)
-    })(_ => IO.unit)
+    async.unsafeRunAsync {
+      StreamSubscription(subscriber, s).map(subscriber.onSubscribe)
+    }(_ => IO.unit)
   }
 
-  private def nonNull[A](a: A): Unit = if(a == null) throw new NullPointerException()
+  private def nonNull[A](a: A): Unit = if (a == null) throw new NullPointerException()
 }
 
 object StreamUnicastPublisher {
-  def apply[F[_], A](s: Stream[F, A])(implicit A: Effect[F], ec: ExecutionContext): StreamUnicastPublisher[F, A] =
+  def apply[F[_]: Effect, A](s: Stream[F, A])
+                            (implicit ec: ExecutionContext): StreamUnicastPublisher[F, A] =
     new StreamUnicastPublisher(s)
 }

--- a/core/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -13,16 +13,19 @@ package object reactivestreams {
     *
     * The publisher only receives a subscriber when the stream is run.
     */
-  def fromPublisher[F[_], A](p: Publisher[A])(implicit A: Effect[F], ec: ExecutionContext): Stream[F, A] = Stream.eval(StreamSubscriber[F, A]().map { s =>
-    p.subscribe(s)
-    s
-  }).flatMap(_.sub.stream)
+  def fromPublisher[F[_]: Effect, A](p: Publisher[A])
+                                    (implicit ec: ExecutionContext): Stream[F, A] =
+    Stream.eval(StreamSubscriber[F, A]().map { s =>
+      p.subscribe(s)
+      s
+    }).flatMap(_.sub.stream)
 
 
   implicit final class PublisherOps[A](val pub: Publisher[A]) extends AnyVal {
 
     /** Creates a lazy stream from an org.reactivestreams.Publisher */
-    def toStream[F[_]]()(implicit A: Effect[F], ec: ExecutionContext): Stream[F, A] = fromPublisher(pub)
+    def toStream[F[_]]()(implicit F: Effect[F], ec: ExecutionContext): Stream[F, A] =
+      fromPublisher(pub)
   }
 
   implicit final class StreamOps[F[_], A](val stream: Stream[F, A]) {
@@ -32,6 +35,7 @@ package object reactivestreams {
       * This publisher can only have a single subscription.
       * The stream is only ran when elements are requested.
       */
-    def toUnicastPublisher()(implicit A: Effect[F], ec: ExecutionContext): StreamUnicastPublisher[F, A] = StreamUnicastPublisher(stream)
+    def toUnicastPublisher()(implicit F: Effect[F], ec: ExecutionContext): StreamUnicastPublisher[F, A] =
+      StreamUnicastPublisher(stream)
   }
 }

--- a/core/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
@@ -2,14 +2,13 @@ package fs2
 package interop
 package reactivestreams
 
-import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
 
 import cats.effect._
 import org.reactivestreams._
 import org.reactivestreams.tck.{PublisherVerification, TestEnvironment}
-import org.scalatest.testng.TestNGSuiteLike
-
-import scala.concurrent.ExecutionContext
+import org.testng.annotations.Test
+import org.scalatest.testng._
 
 class FailedSubscription(sub: Subscriber[_]) extends Subscription {
   def cancel(): Unit = {}
@@ -25,7 +24,7 @@ class FailedPublisher extends Publisher[Int] {
 
 class StreamUnicastPublisherSpec extends PublisherVerification[Int](new TestEnvironment(1000L)) with TestNGSuiteLike {
 
-  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   def createPublisher(n: Long): StreamUnicastPublisher[IO, Int] = {
     val s =

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -9,8 +9,9 @@ A reactive streams implementation for [fs2](https://github.com/functional-stream
 Add the following to your `build.sbt`:
 
 ```tut:silent:fail
-libraryDependencies += "com.github.zainab-ali" %% "fs2-reactive-streams" % "0.1.0"
+libraryDependencies += "com.github.zainab-ali" %% "fs2-reactive-streams" % "0.2.0"
 ```
+This is dependent on version `0.10.0-M5` of fs2.
 
 ## TL;DR
 
@@ -87,6 +88,13 @@ IO.fromFuture(Eval.always(source.runWith(Sink.seq[Int]))).unsafeRunSync()
 ```tut:invisible
 system.terminate()
 ```
+
+## Version Compatability
+
+| fs2        | fs2-reactive-streams |
+|:----------:|:--------------------:|
+| 0.9.4      | 0.1.0                |
+| 0.10.0-M2  | 0.2.0                |
 
 ## Licence
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"


### PR DESCRIPTION
Built on @aeons' work to upgrade to latest fs2.

Makes StreamUnicastPublisher work in a multi-threaded ExecutionContext.  `race` can be won by empty segments.  We need to keep looping as we encounter these, and return `Pull.done` only when we pull a `None`.

Also makes `request` and `cancel` synchronous.  Once interleaved, a cancel might get enqueued before a prior request.