### PR TITLE
Use global execution context for all tests

### DIFF
--- a/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
@@ -2,8 +2,6 @@ package fs2
 package interop
 package reactivestreams
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import org.scalatest._
 import org.scalatest.prop._
@@ -12,7 +10,7 @@ import scala.concurrent.ExecutionContext
 
 class PublisherToSubscriberSpec extends FlatSpec with Matchers with PropertyChecks {
 
-  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   it should "have the same output as input" in { forAll { (ints: Seq[Int]) =>
     val subscriberStream = Stream.emits(ints).covary[IO].toUnicastPublisher.toStream[IO]

--- a/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -2,8 +2,6 @@ package fs2
 package interop
 package reactivestreams
 
-
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
 import cats.effect._
@@ -16,7 +14,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class SubscriberWhiteboxSpec extends SubscriberWhiteboxVerification[Int](new TestEnvironment(1000L)) with TestNGSuiteLike {
-  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+  implicit val ec: ExecutionContext = ExecutionContext.global
   private val counter = new AtomicInteger()
 
   def createSubscriber(p: SubscriberWhiteboxVerification.WhiteboxSubscriberProbe[Int]): Subscriber[Int] =
@@ -26,7 +24,6 @@ class SubscriberWhiteboxSpec extends SubscriberWhiteboxVerification[Int](new Tes
 
   def createElement(i: Int): Int = counter.getAndIncrement
 }
-
 
 final class WhiteboxSubscriber[A](sub: StreamSubscriber[IO, A],
   probe: WhiteboxSubscriberProbe[A]) extends Subscriber[A] {
@@ -61,11 +58,13 @@ final class WhiteboxSubscriber[A](sub: StreamSubscriber[IO, A],
 }
 
 class SubscriberBlackboxSpec extends SubscriberBlackboxVerification[Int](new TestEnvironment(1000L)) with TestNGSuiteLike {
-  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
   val (scheduler: Scheduler, _) =
     Scheduler
       .allocate[IO](corePoolSize = 2, threadPrefix = "subscriber-blackbox-spec-scheduler")
       .unsafeRunSync()
+
   private val counter = new AtomicInteger()
 
   def createSubscriber(): StreamSubscriber[IO, Int] = StreamSubscriber[IO, Int]().unsafeRunSync()


### PR DESCRIPTION
Update the rest of the tests to use the global execution context instead of a single threaded executor.