### PR TITLE
Changes required to update to fs2-0.10.0-M9

### DIFF
--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -117,9 +117,9 @@ object StreamSubscription {
                 case FiniteRequests(n) =>
                   rs.cons(rest).pull.unconsAsync.flatMap(goFinite(aap, _, n))
                 case Cancelled =>
-                  Pull.fail(Cancellation)
+                  Pull.raiseError(Cancellation)
                 case err @ InvalidNumber(_) =>
-                  Pull.fail(err)
+                  Pull.raiseError(err)
               }
           }
         case None =>
@@ -148,8 +148,8 @@ object StreamSubscription {
                 case InfiniteRequests => asyncPull.flatMap(goInfinite(aap, _))
                 case FiniteRequests(m) if m + n > 0L => asyncPull.flatMap(goFinite(aap, _, m + n))
                 case FiniteRequests(_) => asyncPull.flatMap(goInfinite(aap, _))
-                case Cancelled => Pull.fail(Cancellation)
-                case err @ InvalidNumber(_) => Pull.fail(err)
+                case Cancelled => Pull.raiseError(Cancellation)
+                case err @ InvalidNumber(_) => Pull.raiseError(err)
               }
           }
 
@@ -163,7 +163,7 @@ object StreamSubscription {
     ): Pull[F, A, Unit] =
       (aap race rap).pull.flatMap {
         case Left(Some((segment, as))) =>
-          Pull.output(segment) *> as.pull.unconsAsync.flatMap(goInfinite(_, rap))
+          Pull.output(segment) >> as.pull.unconsAsync.flatMap(goInfinite(_, rap))
 
         case Right(Some((requests, rs))) =>
           requests.uncons1 match {
@@ -172,8 +172,8 @@ object StreamSubscription {
               request match {
                 case InfiniteRequests | FiniteRequests(_) =>
                   rs.cons(rest).pull.unconsAsync.flatMap(goInfinite(aap, _))
-                case Cancelled => Pull.fail(Cancellation)
-                case err @ InvalidNumber(_) => Pull.fail(err)
+                case Cancelled => Pull.raiseError(Cancellation)
+                case err @ InvalidNumber(_) => Pull.raiseError(err)
               }
           }
 

--- a/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
@@ -23,7 +23,7 @@ class PublisherToSubscriberSpec extends FlatSpec with Matchers with PropertyChec
   object TestError extends Exception("BOOM")
 
   it should "propagate errors downstream" in {
-    val input: Stream[IO, Int] = Stream(1, 2, 3) ++ Stream.fail(TestError)
+    val input: Stream[IO, Int] = Stream(1, 2, 3) ++ Stream.raiseError(TestError)
     val output: Stream[IO, Int] = input.toUnicastPublisher.toStream[IO]
 
     output.run.attempt.unsafeRunSync() should ===(Left(TestError))


### PR DESCRIPTION
Note this fs2 version hasn't been released yet, but I've built a snapshot locally
to test performance / memory leak fixes and also needed to make these changes.

When fs2 is released, the build.sbt dep will need to be updated. 

No need to merge yet, but this may help soon.