### PR TITLE
Upgrade fs2 to 0.10.0-M9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val commonSettings = Seq(
     resolvers ++= commonResolvers,
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.10.0-M8",
+      "co.fs2" %% "fs2-core" % "0.10.0-M9",
       "org.reactivestreams" % "reactive-streams" % "1.0.1",
       "org.scalatest" %% "scalatest" % "3.0.3" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -47,7 +47,7 @@ final class StreamSubscription[F[_], A](
     }
 
   def cancel(): Unit =
-    F.runAsync(cancelled.setSyncPure(true) *> requests.enqueue1(Cancelled))(_ => IO.unit)
+    F.runAsync(cancelled.setSync(true) *> requests.enqueue1(Cancelled))(_ => IO.unit)
       .unsafeRunSync()
 
   def request(n: Long): Unit = {
@@ -107,7 +107,7 @@ object StreamSubscription {
     ): Pull[F, A, Unit] =
       rap.pull.flatMap {
         case Some((requests, rs)) =>
-          requests.uncons1 match {
+          requests.force.uncons1 match {
             case Left(()) =>
               rs.pull.unconsAsync.flatMap(go(aap, _))
             case Right((request, rest)) =>
@@ -117,9 +117,9 @@ object StreamSubscription {
                 case FiniteRequests(n) =>
                   rs.cons(rest).pull.unconsAsync.flatMap(goFinite(aap, _, n))
                 case Cancelled =>
-                  Pull.fail(Cancellation)
+                  Pull.raiseError(Cancellation)
                 case err @ InvalidNumber(_) =>
-                  Pull.fail(err)
+                  Pull.raiseError(err)
               }
           }
         case None =>
@@ -139,7 +139,7 @@ object StreamSubscription {
           }
 
         case Right(Some((requests, rs))) =>
-          requests.uncons1 match {
+          requests.force.uncons1 match {
             case Left(()) =>
               rs.pull.unconsAsync.flatMap(goFinite(aap, _, n))
             case Right((request, rest)) =>
@@ -148,8 +148,8 @@ object StreamSubscription {
                 case InfiniteRequests => asyncPull.flatMap(goInfinite(aap, _))
                 case FiniteRequests(m) if m + n > 0L => asyncPull.flatMap(goFinite(aap, _, m + n))
                 case FiniteRequests(_) => asyncPull.flatMap(goInfinite(aap, _))
-                case Cancelled => Pull.fail(Cancellation)
-                case err @ InvalidNumber(_) => Pull.fail(err)
+                case Cancelled => Pull.raiseError(Cancellation)
+                case err @ InvalidNumber(_) => Pull.raiseError(err)
               }
           }
 
@@ -163,17 +163,17 @@ object StreamSubscription {
     ): Pull[F, A, Unit] =
       (aap race rap).pull.flatMap {
         case Left(Some((segment, as))) =>
-          Pull.output(segment) *> as.pull.unconsAsync.flatMap(goInfinite(_, rap))
+          Pull.output(segment) >> as.pull.unconsAsync.flatMap(goInfinite(_, rap))
 
         case Right(Some((requests, rs))) =>
-          requests.uncons1 match {
+          requests.force.uncons1 match {
             case Left(()) => rs.pull.unconsAsync.flatMap(goInfinite(aap, _))
             case Right((request, rest)) =>
               request match {
                 case InfiniteRequests | FiniteRequests(_) =>
                   rs.cons(rest).pull.unconsAsync.flatMap(goInfinite(aap, _))
-                case Cancelled => Pull.fail(Cancellation)
-                case err @ InvalidNumber(_) => Pull.fail(err)
+                case Cancelled => Pull.raiseError(Cancellation)
+                case err @ InvalidNumber(_) => Pull.raiseError(err)
               }
           }
 

--- a/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
@@ -23,7 +23,7 @@ class PublisherToSubscriberSpec extends FlatSpec with Matchers with PropertyChec
   object TestError extends Exception("BOOM")
 
   it should "propagate errors downstream" in {
-    val input: Stream[IO, Int] = Stream(1, 2, 3) ++ Stream.fail(TestError)
+    val input: Stream[IO, Int] = Stream(1, 2, 3) ++ Stream.raiseError(TestError)
     val output: Stream[IO, Int] = input.toUnicastPublisher.toStream[IO]
 
     output.run.attempt.unsafeRunSync() should ===(Left(TestError))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.4


### PR DESCRIPTION
There are some `.setAsyncPure` on the old `Ref` that have been changed to `.complete` on the new `Promise`, which I believe is the equivalent of the old `.setSyncPure`.
I have not seen it fail, in many test runs, but I'm not sure if the tests would catch an error here.

I have also tried `fs2.async.fork(r.complete(...))` as mentioned in the comment for `.complete`, but with this the tests failed once out of several runs.

I am not sure whether it's important that those operations are async though.