### PR TITLE
Refactor Subscriber

### DIFF
--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -48,10 +48,10 @@ final class StreamSubscriber[F[_], A](val sub: StreamSubscriber.FSM[F, A])(impli
 }
 
 object StreamSubscriber {
-  def apply[F[_], A]()(implicit AA: Effect[F], ec: ExecutionContext): F[StreamSubscriber[F, A]] =
+  def apply[F[_], A](implicit AA: Effect[F], ec: ExecutionContext): F[StreamSubscriber[F, A]] =
     fsm[F, A].map(new StreamSubscriber(_))
 
-  /** A finite state machine descriving the subscriber */
+  /** A finite state machine describing the subscriber */
   private[reactivestreams] trait FSM[F[_], A] {
 
     /** receives a subscription from upstream */
@@ -73,7 +73,7 @@ object StreamSubscriber {
     def dequeue1: F[Either[Throwable, Option[A]]]
 
     /** downstream stream */
-    def stream()(implicit A: Applicative[F]): Stream[F, A] =
+    def stream()(implicit ev: Applicative[F]): Stream[F, A] =
       Stream.eval(dequeue1).repeat.rethrow.unNoneTerminate.onFinalize(onFinalize)
   }
 
@@ -91,60 +91,46 @@ object StreamSubscriber {
     case class OnDequeue(response: Promise[F, Out]) extends Input
 
     sealed trait State
-
-    /** No requests have been made (the downstream [[fs2.Stream]] has not been pulled on) */
     case object Uninitialized extends State
-
-    /** No downstream requests are open and a subscription has been received. */
     case class Idle(sub: Subscription) extends State
-
-    /** The first downstream request has been made, but a subscription has not been received from upstream */
-    case class FirstRequest(req: Promise[F, Out]) extends State
-
-    /** The subscriber has requested an element from upstream, but not yet received it */
-    case class PendingElement(sub: Subscription, req: Promise[F, Out]) extends State
-
-    /** The upstream publisher has completed successfully */
-    case object Complete extends State
-
-    /** Downstream finished before upstream completed.  The subscription has been cancelled. */
-    case object Cancelled extends State
-
-    /** An error was received from upstream */
-    case class Errored(err: Throwable) extends State
+    case class RequestBeforeSubscription(req: Promise[F, Out]) extends State
+    case class WaitingOnUpstream(sub: Subscription, elementRequest: Promise[F, Out]) extends State
+    case object UpstreamCompletion extends State
+    case object DownstreamCancellation extends State
+    case class UpstreamError(err: Throwable) extends State
 
     def step(in: Input): State => (State, F[Unit]) = in match {
       case OnSubscribe(s) => {
-        case FirstRequest(req) => PendingElement(s, req) -> F.delay(s.request(1))
+        case RequestBeforeSubscription(req) => WaitingOnUpstream(s, req) -> F.delay(s.request(1))
         case Uninitialized => Idle(s) -> F.unit
         case o =>
           val err = new Error(s"received subscription in invalid state [$o]")
           o -> F.delay(s.cancel) *> F.raiseError(err)
       }
       case OnNext(a) => {
-        case PendingElement(s, r) => Idle(s) -> r.complete(a.some.asRight)
-        case Cancelled => Cancelled -> F.unit
+        case WaitingOnUpstream(s, r) => Idle(s) -> r.complete(a.some.asRight)
+        case c @ DownstreamCancellation => c -> F.unit
         case o => o -> F.raiseError(new Error(s"received record [$a] in invalid state [$o]"))
       }
       case OnComplete => {
-        case PendingElement(sub, r) => Complete -> r.complete(None.asRight)
-        case o => Complete -> F.unit
+        case WaitingOnUpstream(sub, r) => UpstreamCompletion -> r.complete(None.asRight)
+        case o => UpstreamCompletion -> F.unit
       }
       case OnError(e) => {
-        case PendingElement(sub, r) => Errored(e) -> r.complete(e.asLeft)
-        case o => Errored(e) -> F.unit
+        case WaitingOnUpstream(_, r) => UpstreamError(e) -> r.complete(e.asLeft)
+        case o => UpstreamError(e) -> F.unit
       }
       case OnFinalize => {
-        case PendingElement(sub, r) =>
-          Cancelled -> (F.delay(sub.cancel) *> r.complete(None.asRight))
-        case Idle(sub) => Cancelled -> F.delay(sub.cancel)
+        case WaitingOnUpstream(sub, r) =>
+          DownstreamCancellation -> F.delay(sub.cancel) *> r.complete(None.asRight)
+        case Idle(sub) => DownstreamCancellation -> F.delay(sub.cancel)
         case o => o -> F.unit
       }
       case OnDequeue(r) => {
-        case Uninitialized => FirstRequest(r) -> F.unit
-        case Idle(sub) => PendingElement(sub, r) -> F.delay(sub.request(1))
-        case Errored(e) => Errored(e) -> r.complete(e.asLeft)
-        case Complete => Complete -> r.complete(None.asRight)
+        case Uninitialized => RequestBeforeSubscription(r) -> F.unit
+        case Idle(sub) => WaitingOnUpstream(sub, r) -> F.delay(sub.request(1))
+        case err @ UpstreamError(e) => err -> r.complete(e.asLeft)
+        case c @ UpstreamCompletion => c -> r.complete(None.asRight)
         case o => o -> r.complete((new Error(s"received request in invalid state [$o]")).asLeft)
       }
     }

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -73,7 +73,7 @@ object StreamSubscriber {
     def dequeue1: F[Either[Throwable, Option[A]]]
 
     /** downstream stream */
-    def stream()(implicit ev: Applicative[F]): Stream[F, A] =
+    def stream(implicit ev: Applicative[F]): Stream[F, A] =
       Stream.eval(dequeue1).repeat.rethrow.unNoneTerminate.onFinalize(onFinalize)
   }
 

--- a/core/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -17,7 +17,7 @@ package object reactivestreams {
     p: Publisher[A]
   )(implicit ec: ExecutionContext): Stream[F, A] =
     Stream
-      .eval(StreamSubscriber[F, A]().map { s =>
+      .eval(StreamSubscriber[F, A].map { s =>
         p.subscribe(s)
         s
       })

--- a/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -29,7 +29,7 @@ class SubscriberWhiteboxSpec
   def createSubscriber(
     p: SubscriberWhiteboxVerification.WhiteboxSubscriberProbe[Int]
   ): Subscriber[Int] =
-    StreamSubscriber[IO, Int]()
+    StreamSubscriber[IO, Int]
       .map { s =>
         new WhiteboxSubscriber(s, p)
       }
@@ -84,7 +84,7 @@ class SubscriberBlackboxSpec
 
   private val counter = new AtomicInteger()
 
-  def createSubscriber(): StreamSubscriber[IO, Int] = StreamSubscriber[IO, Int]().unsafeRunSync()
+  def createSubscriber(): StreamSubscriber[IO, Int] = StreamSubscriber[IO, Int].unsafeRunSync()
 
   override def triggerRequest(s: Subscriber[_ >: Int]): Unit = {
     val req = s.asInstanceOf[StreamSubscriber[IO, Int]].sub.dequeue1


### PR DESCRIPTION
This PR refactors Subscriber, in mainly two ways:

- It removes several side effects due to the use of `pure` when `delay` is needed
- It centralises the code that handles the state machine transition, so that it can be understood by looking in one place only