### PR TITLE
Upgrade to fs2-1.0.0-M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 
 lazy val buildSettings = Seq(
   organization := "com.github.zainab-ali",
-  crossScalaVersions := List("2.12.4", "2.11.12"),
+  crossScalaVersions := List("2.12.6", "2.11.12"),
   scalaVersion := crossScalaVersions.value.head,
   name := "fs2-reactive-streams"
 )
@@ -28,9 +28,9 @@ lazy val commonSettings = Seq(
     resolvers ++= commonResolvers,
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.10.1",
+      "co.fs2" %% "fs2-core" % "1.0.0-M1",
       "org.reactivestreams" % "reactive-streams" % "1.0.2",
-      "org.scalatest" %% "scalatest" % "3.0.4" % "test",
+      "org.scalatest" %% "scalatest" % "3.0.5" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",
       "org.reactivestreams" % "reactive-streams-tck" % "1.0.2" % "test"
     )

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -20,7 +20,7 @@ final class StreamSubscription[F[_], A](
   cancelled: Signal[F, Boolean],
   sub: Subscriber[A],
   stream: Stream[F, A]
-)(implicit F: Effect[F], ec: ExecutionContext)
+)(implicit F: ConcurrentEffect[F], timer: Timer[F])
     extends Subscription {
   import StreamSubscription._
 
@@ -92,8 +92,8 @@ object StreamSubscription {
   case object Infinite extends Request
   case class Finite(n: Long) extends Request
 
-  def apply[F[_]: Effect, A](sub: Subscriber[A], stream: Stream[F, A])(
-    implicit ec: ExecutionContext
+  def apply[F[_]: ConcurrentEffect, A](sub: Subscriber[A], stream: Stream[F, A])(
+    implicit timer: Timer[F]
   ): F[StreamSubscription[F, A]] =
     async.signalOf[F, Boolean](false).flatMap { cancelled =>
       async.unboundedQueue[F, Request].map { requests =>

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -15,9 +15,9 @@ import scala.concurrent.ExecutionContext
   * @see https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code
   *
   */
-final class StreamUnicastPublisher[F[_]: Effect, A](
+final class StreamUnicastPublisher[F[_]: ConcurrentEffect, A](
   val s: Stream[F, A]
-)(implicit ec: ExecutionContext)
+)(implicit timer: Timer[F])
     extends Publisher[A] {
 
   def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
@@ -37,8 +37,8 @@ final class StreamUnicastPublisher[F[_]: Effect, A](
 }
 
 object StreamUnicastPublisher {
-  def apply[F[_]: Effect, A](
+  def apply[F[_]: ConcurrentEffect, A](
     s: Stream[F, A]
-  )(implicit ec: ExecutionContext): StreamUnicastPublisher[F, A] =
+  )(implicit timer: Timer[F]): StreamUnicastPublisher[F, A] =
     new StreamUnicastPublisher(s)
 }

--- a/core/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -13,9 +13,9 @@ package object reactivestreams {
     *
     * The publisher only receives a subscriber when the stream is run.
     */
-  def fromPublisher[F[_]: Effect, A](
+  def fromPublisher[F[_]: ConcurrentEffect, A](
     p: Publisher[A]
-  )(implicit ec: ExecutionContext): Stream[F, A] =
+  )(implicit timer: Timer[F]): Stream[F, A] =
     Stream
       .eval(StreamSubscriber[F, A].map { s =>
         p.subscribe(s)
@@ -26,7 +26,7 @@ package object reactivestreams {
   implicit final class PublisherOps[A](val pub: Publisher[A]) extends AnyVal {
 
     /** Creates a lazy stream from an org.reactivestreams.Publisher */
-    def toStream[F[_]]()(implicit F: Effect[F], ec: ExecutionContext): Stream[F, A] =
+    def toStream[F[_]]()(implicit F: ConcurrentEffect[F], timer: Timer[F]): Stream[F, A] =
       fromPublisher(pub)
   }
 
@@ -37,8 +37,8 @@ package object reactivestreams {
       * This publisher can only have a single subscription.
       * The stream is only ran when elements are requested.
       */
-    def toUnicastPublisher()(implicit F: Effect[F],
-                             ec: ExecutionContext): StreamUnicastPublisher[F, A] =
+    def toUnicastPublisher()(implicit F: ConcurrentEffect[F],
+                             timer: Timer[F]): StreamUnicastPublisher[F, A] =
       StreamUnicastPublisher(stream)
   }
 }

--- a/core/version.sbt
+++ b/core/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2-SNAPSHOT"
+version in ThisBuild := "0.6.0-SNAPSHOT"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.6


### PR DESCRIPTION
* `ExecutionContext` is replaced by `Timer`
* `Effect` is still necessary for `unsafeRunAsync`s.
* `Concurrent` is necessary for `Deferred`, which replaces `Promise`.
* `Effect` + `Concurrent` = `ConcurrentEffect`

Maybe we can whittle this down some more, but this is a minimal update that passes all tests.