### PR TITLE
Upgrade to fs2 1.0.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val commonSettings = Seq(
     resolvers ++= commonResolvers,
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "1.0.0-M1",
+      "co.fs2" %% "fs2-core" % "1.0.0-M4",
       "org.reactivestreams" % "reactive-streams" % "1.0.2",
       "org.scalatest" %% "scalatest" % "3.0.5" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -16,12 +16,10 @@ import scala.concurrent.ExecutionContext
   *
   * @see https://github.com/reactive-streams/reactive-streams-jvm#3-subscription-code
   */
-final class StreamSubscription[F[_], A](
-  requests: Queue[F, StreamSubscription.Request],
-  cancelled: Signal[F, Boolean],
-  sub: Subscriber[A],
-  stream: Stream[F, A]
-)(implicit F: ConcurrentEffect[F])
+final class StreamSubscription[F[_], A](requests: Queue[F, StreamSubscription.Request],
+                                        cancelled: Signal[F, Boolean],
+                                        sub: Subscriber[A],
+                                        stream: Stream[F, A])(implicit F: ConcurrentEffect[F])
     extends Subscription {
   import StreamSubscription._
 
@@ -88,7 +86,8 @@ object StreamSubscription {
   case object Infinite extends Request
   case class Finite(n: Long) extends Request
 
-  def apply[F[_]: ConcurrentEffect, A](sub: Subscriber[A], stream: Stream[F, A]): F[StreamSubscription[F, A]] =
+  def apply[F[_]: ConcurrentEffect, A](sub: Subscriber[A],
+                                       stream: Stream[F, A]): F[StreamSubscription[F, A]] =
     async.signalOf[F, Boolean](false).flatMap { cancelled =>
       async.unboundedQueue[F, Request].map { requests =>
         new StreamSubscription(requests, cancelled, sub, stream)

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -3,6 +3,7 @@ package interop
 package reactivestreams
 
 import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import fs2._, async.mutable.{Signal, Queue}
 import org.reactivestreams._
@@ -20,7 +21,7 @@ final class StreamSubscription[F[_], A](
   cancelled: Signal[F, Boolean],
   sub: Subscriber[A],
   stream: Stream[F, A]
-)(implicit F: ConcurrentEffect[F], timer: Timer[F])
+)(implicit F: ConcurrentEffect[F])
     extends Subscription {
   import StreamSubscription._
 
@@ -54,7 +55,7 @@ final class StreamSubscription[F[_], A](
         .compile
         .drain
 
-    async.unsafeRunAsync(s)(_ => IO.unit)
+    s.unsafeRunAsync
   }
 
   // According to the spec, it's acceptable for a concurrent cancel to not
@@ -65,12 +66,7 @@ final class StreamSubscription[F[_], A](
   // See https://github.com/zainab-ali/fs2-reactive-streams/issues/29
   // and https://github.com/zainab-ali/fs2-reactive-streams/issues/46
   def cancel(): Unit =
-    IO.async[Unit] { cb =>
-        async.unsafeRunAsync {
-          cancelled.set(true) *> F.delay(cb(Right()))
-        }(_ => IO.unit)
-      }
-      .unsafeRunSync
+    cancelled.set(true).toIO.unsafeRunSync
 
   def request(n: Long): Unit = {
     val request =
@@ -81,7 +77,7 @@ final class StreamSubscription[F[_], A](
     val prog = cancelled.get
       .ifM(ifTrue = F.unit, ifFalse = request.flatMap(requests.enqueue1).handleErrorWith(onError))
 
-    async.unsafeRunAsync(prog)(_ => IO.unit)
+    prog.unsafeRunAsync
   }
 }
 
@@ -92,9 +88,7 @@ object StreamSubscription {
   case object Infinite extends Request
   case class Finite(n: Long) extends Request
 
-  def apply[F[_]: ConcurrentEffect, A](sub: Subscriber[A], stream: Stream[F, A])(
-    implicit timer: Timer[F]
-  ): F[StreamSubscription[F, A]] =
+  def apply[F[_]: ConcurrentEffect, A](sub: Subscriber[A], stream: Stream[F, A]): F[StreamSubscription[F, A]] =
     async.signalOf[F, Boolean](false).flatMap { cancelled =>
       async.unboundedQueue[F, Request].map { requests =>
         new StreamSubscription(requests, cancelled, sub, stream)

--- a/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -16,9 +16,8 @@ import scala.concurrent.ExecutionContext
   * @see https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code
   *
   */
-final class StreamUnicastPublisher[F[_]: ConcurrentEffect, A](
-  val s: Stream[F, A]
-) extends Publisher[A] {
+final class StreamUnicastPublisher[F[_]: ConcurrentEffect, A](val s: Stream[F, A])
+    extends Publisher[A] {
 
   def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
     nonNull(subscriber)
@@ -30,13 +29,10 @@ final class StreamUnicastPublisher[F[_]: ConcurrentEffect, A](
     }.unsafeRunAsync
   }
 
-
   private def nonNull[A](a: A): Unit = if (a == null) throw new NullPointerException()
 }
 
 object StreamUnicastPublisher {
-  def apply[F[_]: ConcurrentEffect, A](
-    s: Stream[F, A]
-  ): StreamUnicastPublisher[F, A] =
+  def apply[F[_]: ConcurrentEffect, A](s: Stream[F, A]): StreamUnicastPublisher[F, A] =
     new StreamUnicastPublisher(s)
 }

--- a/core/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -3,6 +3,7 @@ package interop
 
 import cats.effect._
 import cats.implicits._
+import cats.effect.implicits._
 import org.reactivestreams._
 
 import scala.concurrent.ExecutionContext
@@ -13,20 +14,16 @@ package object reactivestreams {
     *
     * The publisher only receives a subscriber when the stream is run.
     */
-  def fromPublisher[F[_]: ConcurrentEffect, A](
-    p: Publisher[A]
-  )(implicit timer: Timer[F]): Stream[F, A] =
+  def fromPublisher[F[_]: ConcurrentEffect, A](p: Publisher[A]): Stream[F, A] =
     Stream
-      .eval(StreamSubscriber[F, A].map { s =>
-        p.subscribe(s)
-        s
-      })
+      .eval(StreamSubscriber[F, A])
+      .evalTap { s => Sync[F] delay p.subscribe(s) }
       .flatMap(_.sub.stream)
 
   implicit final class PublisherOps[A](val pub: Publisher[A]) extends AnyVal {
 
     /** Creates a lazy stream from an org.reactivestreams.Publisher */
-    def toStream[F[_]]()(implicit F: ConcurrentEffect[F], timer: Timer[F]): Stream[F, A] =
+    def toStream[F[_]: ConcurrentEffect](): Stream[F, A] =
       fromPublisher(pub)
   }
 
@@ -37,8 +34,22 @@ package object reactivestreams {
       * This publisher can only have a single subscription.
       * The stream is only ran when elements are requested.
       */
-    def toUnicastPublisher()(implicit F: ConcurrentEffect[F],
-                             timer: Timer[F]): StreamUnicastPublisher[F, A] =
+    def toUnicastPublisher()(implicit F: ConcurrentEffect[F]): StreamUnicastPublisher[F, A] =
       StreamUnicastPublisher(stream)
   }
+
+  private[interop] implicit class Runner[F[_]: ConcurrentEffect, A](fa: F[A]) {
+    def reportFailure(e: Throwable) =
+      Thread.getDefaultUncaughtExceptionHandler match {
+        case null => e.printStackTrace()
+        case h => h.uncaughtException(Thread.currentThread(), e)
+      }
+
+    def unsafeRunAsync: Unit =
+      fa.runAsync {
+        case Left(e) => IO(reportFailure(e))
+        case Right(_) => IO.unit
+      }.unsafeRunSync
+  }
 }
+  

--- a/core/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/core/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -17,7 +17,9 @@ package object reactivestreams {
   def fromPublisher[F[_]: ConcurrentEffect, A](p: Publisher[A]): Stream[F, A] =
     Stream
       .eval(StreamSubscriber[F, A])
-      .evalTap { s => Sync[F] delay p.subscribe(s) }
+      .evalTap { s =>
+        Sync[F] delay p.subscribe(s)
+      }
       .flatMap(_.sub.stream)
 
   implicit final class PublisherOps[A](val pub: Publisher[A]) extends AnyVal {
@@ -52,4 +54,3 @@ package object reactivestreams {
       }.unsafeRunSync
   }
 }
-  

--- a/core/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
@@ -5,8 +5,8 @@ package reactivestreams
 import org.reactivestreams._
 import cats.effect._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.ExecutionContext
 
 import org.scalatest.FunSuite
 
@@ -17,6 +17,10 @@ import org.scalatest.FunSuite
   * failures due to race conditions more repeatable
   */
 class CancellationSpec extends FunSuite {
+  implicit val ctx: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
+
   case class Sub[A](b: AtomicBoolean) extends Subscriber[A] {
     def onNext(t: A) = b.set(true)
     def onComplete() = b.set(true)

--- a/core/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
@@ -26,14 +26,15 @@ class StreamUnicastPublisherSpec
     extends PublisherVerification[Int](new TestEnvironment(1000L))
     with TestNGSuiteLike {
 
-  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val ctx: ContextShift[IO] =
+      IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
 
   def createPublisher(n: Long): StreamUnicastPublisher[IO, Int] = {
     val s =
       if (n == java.lang.Long.MAX_VALUE) Stream.range(1, 20).repeat
       else Stream(1).repeat.scan(1)(_ + _).map(i => if (i > n) None else Some(i)).unNoneTerminate
 
-    s.covary[IO].toUnicastPublisher()
+    s.covary[IO].toUnicastPublisher
   }
 
   def createFailedPublisher(): FailedPublisher = new FailedPublisher()

--- a/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -24,7 +24,10 @@ import scala.concurrent.duration._
 class SubscriberWhiteboxSpec
     extends SubscriberWhiteboxVerification[Int](new TestEnvironment(1000L))
     with TestNGSuiteLike {
-  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  implicit val ctx: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
   private val counter = new AtomicInteger()
 
   def createSubscriber(
@@ -76,9 +79,9 @@ final class WhiteboxSubscriber[A](sub: StreamSubscriber[IO, A], probe: WhiteboxS
 class SubscriberBlackboxSpec
     extends SubscriberBlackboxVerification[Int](new TestEnvironment(1000L))
     with TestNGSuiteLike {
-  implicit val ec: ExecutionContext = ExecutionContext.global
 
-  val timer = Timer[IO]
+  val timer = IO.timer(ExecutionContext.global)
+  implicit val ctx = IO.contextShift(ExecutionContext.global)
 
   private val counter = new AtomicInteger()
 

--- a/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/core/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -81,7 +81,7 @@ class SubscriberBlackboxSpec
     with TestNGSuiteLike {
 
   val timer = IO.timer(ExecutionContext.global)
-  implicit val ctx = IO.contextShift(ExecutionContext.global)
+  implicit val ctx: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   private val counter = new AtomicInteger()
 


### PR DESCRIPTION
Do not merge yet, we need an M4 because of https://github.com/functional-streams-for-scala/fs2/pull/1215

I've already made sure the tests pass with the fix though, so it should be good to go once M4 is out.